### PR TITLE
fix: do not crash when "paths" is not defined

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -62,8 +62,7 @@ function getSubtitle(project) {
  */
 function getIcon(project) {
 
-  const iconPaths = project
-    .paths
+  const iconPaths = (project.paths || [])
     .map(projectPath => path.join(projectPath, 'icon.png'));
 
   return Object


### PR DESCRIPTION
I had this plugin crashing when `paths` is not defined in the object. 
simple fallback to make sure we don't crash for silly errors